### PR TITLE
resolves #15 convert tabs block to openblock

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,7 +14,11 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
  ** `.tab-panel` becomes `.tabpanel`
  ** `.is-active` for selected tab becomes `.is-selected`
  ** `.is-active` for visible panel becomes `:not(.is-hidden)`
-* Assign ARIA attributes in JavaScript (i.e., role, aria-controls, aria-hidden) where recommended (#38)
+* Assign ARIA attributes in JavaScript (i.e., role, aria-controls, aria-selected, hidden) where recommended (#38)
+* *BREAKING CHANGE:* Convert tabs block to openblock instead of passthrough block
+ ** `openblock` class added to `.tabs`
+ ** `.tablist` becomes child of `.content`
+ ** `.tabpanel` elements become siblings of `.tablist`
 
 === Fixed
 

--- a/lib/asciidoctor/tabs/block.rb
+++ b/lib/asciidoctor/tabs/block.rb
@@ -19,12 +19,9 @@ module Asciidoctor
         tabs_number = doc.counter 'tabs-number'
         tabs_id = attrs['id'] || (generate_id %(tabs #{tabs_number}), doc)
         sync = !(block.option? 'nosync') && ((block.option? 'sync') || (doc.option? 'tabs-sync')) ? ' is-sync' : nil
-        parent << (create_html_fragment parent, %(<div id="#{tabs_id}" class="tabs#{sync || ''} is-loading">))
-        if (title = attrs['title'])
-          parent << (create_html_fragment parent, %(<div class="title">#{parent.apply_subs title}</div>))
-        end
-        tablist = create_list parent, :ulist
-        tablist.role = 'tablist'
+        tabs = create_open_block parent, nil, { 'id' => tabs_id, 'role' => %(tabs#{sync || ''} is-loading) }
+        tabs.title = attrs['title']
+        tablist = create_list parent, :ulist, { 'role' => 'tablist' }
         panes = {}
         set_id_on_tab = (doc.backend == 'html5') || (list_item_supports_id? doc)
         seed_tabs.items.each do |labels, content|
@@ -49,16 +46,14 @@ module Asciidoctor
           end
           panes[tab_ids] = tab_blocks || []
         end
-        parent << tablist
-        parent << (create_html_fragment parent, '<div class="content">')
+        tabs << tablist
         panes.each do |tab_ids, blocks|
           attrs = %( id="#{tab_ids[0]}--panel" class="tabpanel" aria-labelledby="#{tab_ids.join ' '}")
-          parent << (create_html_fragment parent, %(<div#{attrs}>))
-          blocks.each {|it| parent << it }
-          parent << (create_html_fragment parent, '</div>')
+          tabs << (create_html_fragment parent, %(<div#{attrs}>))
+          blocks.each {|it| tabs << it }
+          tabs << (create_html_fragment parent, '</div>')
         end
-        parent << (create_html_fragment parent, '</div>')
-        create_html_fragment parent, '</div>', 'id' => tabs_id
+        tabs
       end
 
       private

--- a/spec/tabs_spec.rb
+++ b/spec/tabs_spec.rb
@@ -182,7 +182,8 @@ describe Asciidoctor::Tabs do
     it 'should convert custom tabs block containing valid content' do
       input = two_tabs
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
+      <div class="content">
       <div class="ulist tablist">
       <ul>
       <li id="_tabs_1_tab_a" class="tab">
@@ -193,7 +194,6 @@ describe Asciidoctor::Tabs do
       </li>
       </ul>
       </div>
-      <div class="content">
       <div id="_tabs_1_tab_a--panel" class="tabpanel" aria-labelledby="_tabs_1_tab_a">
       <div class="paragraph">
       <p>Contents of tab A.</p>
@@ -230,8 +230,9 @@ describe Asciidoctor::Tabs do
 
       actual = Asciidoctor.convert input
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
       <div class="title">These are <strong>tabs</strong>!</div>
+      <div class="content">
       <div class="ulist tablist">
       END
       (expect actual).to include expected
@@ -397,7 +398,8 @@ describe Asciidoctor::Tabs do
       END
 
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
+      <div class="content">
       <div class="ulist tablist">
       <ul>
       <li id="_tabs_1_tab_a" class="tab">
@@ -408,7 +410,6 @@ describe Asciidoctor::Tabs do
       </li>
       </ul>
       </div>
-      <div class="content">
       <div id="_tabs_1_tab_a--panel" class="tabpanel" aria-labelledby="_tabs_1_tab_a">
       <div class="paragraph">
       <p>Contents of tab A.</p>
@@ -438,7 +439,8 @@ describe Asciidoctor::Tabs do
       END
 
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
+      <div class="content">
       <div class="ulist tablist">
       <ul>
       <li id="_tabs_1_tab_a" class="tab">
@@ -446,7 +448,6 @@ describe Asciidoctor::Tabs do
       </li>
       </ul>
       </div>
-      <div class="content">
       <div id="_tabs_1_tab_a--panel" class="tabpanel" aria-labelledby="_tabs_1_tab_a">
       <div class="paragraph">
       <p>Text</p>
@@ -478,7 +479,8 @@ describe Asciidoctor::Tabs do
       END
 
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
+      <div class="content">
       <div class="ulist tablist">
       <ul>
       <li id="_tabs_1_download" class="tab">
@@ -489,7 +491,6 @@ describe Asciidoctor::Tabs do
       </li>
       </ul>
       </div>
-      <div class="content">
       <div id="_tabs_1_download--panel" class="tabpanel" aria-labelledby="_tabs_1_download">
       <div class="paragraph">
       <p>Download the <strong>installer</strong> from <a href="https://example.org" class="bare">example.org</a>.</p>
@@ -525,7 +526,8 @@ describe Asciidoctor::Tabs do
       END
 
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
+      <div class="content">
       <div class="ulist tablist">
       <ul>
       <li id="_tabs_1_tab_a" class="tab">
@@ -539,7 +541,6 @@ describe Asciidoctor::Tabs do
       </li>
       </ul>
       </div>
-      <div class="content">
       <div id="_tabs_1_tab_a--panel" class="tabpanel" aria-labelledby="_tabs_1_tab_a _tabs_1_tab_b">
       <div class="paragraph">
       <p>Shared contents for tab A and B.</p>
@@ -568,7 +569,8 @@ describe Asciidoctor::Tabs do
       END
 
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
+      <div class="content">
       <div class="ulist tablist">
       <ul>
       <li id="_tabs_1_tab_a" class="tab">
@@ -579,7 +581,6 @@ describe Asciidoctor::Tabs do
       </li>
       </ul>
       </div>
-      <div class="content">
       <div id="_tabs_1_tab_a--panel" class="tabpanel" aria-labelledby="_tabs_1_tab_a">
       <div class="paragraph">
       <p>Contents of tab A.</p>
@@ -610,7 +611,8 @@ describe Asciidoctor::Tabs do
       END
 
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
+      <div class="content">
       <div class="ulist tablist">
       <ul>
       <li id="_tabs_1_tab_a" class="tab">
@@ -618,7 +620,6 @@ describe Asciidoctor::Tabs do
       </li>
       </ul>
       </div>
-      <div class="content">
       <div id="_tabs_1_tab_a--panel" class="tabpanel" aria-labelledby="_tabs_1_tab_a">
       <div class="paragraph">
       <p>Contents of tab A.</p>
@@ -648,7 +649,8 @@ describe Asciidoctor::Tabs do
       END
 
       expected = <<~'END'.chomp
-      <div id="_tabs_1" class="tabs is-loading">
+      <div id="_tabs_1" class="openblock tabs is-loading">
+      <div class="content">
       <div class="ulist tablist">
       <ul>
       <li id="_tabs_1_tab_a" class="tab">
@@ -656,7 +658,6 @@ describe Asciidoctor::Tabs do
       </li>
       </ul>
       </div>
-      <div class="content">
       <div id="_tabs_1_tab_a--panel" class="tabpanel" aria-labelledby="_tabs_1_tab_a">
       <div class="literalblock">
       <div class="content">
@@ -733,7 +734,7 @@ describe Asciidoctor::Tabs do
       END
 
       actual = Asciidoctor.convert input
-      (expect actual).to include ' class="tabs is-sync is-loading"'
+      (expect actual).to include ' class="openblock tabs is-sync is-loading"'
     end
 
     it 'should add is-sync class to tabs block if sync option is set on block' do
@@ -743,7 +744,7 @@ describe Asciidoctor::Tabs do
       END
 
       actual = Asciidoctor.convert input
-      (expect actual).to include ' class="tabs is-sync is-loading"'
+      (expect actual).to include ' class="openblock tabs is-sync is-loading"'
     end
 
     it 'should not add is-sync class to tabs block if nosync option is set on block' do
@@ -755,8 +756,8 @@ describe Asciidoctor::Tabs do
       END
 
       actual = Asciidoctor.convert input
-      (expect actual).not_to include ' class="tabs is-sync is-loading"'
-      (expect actual).to include ' class="tabs is-loading"'
+      (expect actual).not_to include ' class="openblock tabs is-sync is-loading"'
+      (expect actual).to include ' class="openblock tabs is-loading"'
     end
   end
 
@@ -954,7 +955,7 @@ describe Asciidoctor::Tabs do
       described_class::Extensions.register Asciidoctor::Extensions
       input = hello_tabs
       actual = Asciidoctor.convert input
-      (expect actual).to include 'class="tabs'
+      (expect actual).to include ' class="openblock tabs is-loading"'
     end
 
     it 'should register extensions on specified local registry' do
@@ -962,7 +963,7 @@ describe Asciidoctor::Tabs do
       described_class::Extensions.register (registry = Asciidoctor::Extensions.create)
       input = hello_tabs
       actual = Asciidoctor.convert input, extension_registry: registry
-      (expect actual).to include 'class="tabs'
+      (expect actual).to include ' class="openblock tabs is-loading"'
     end
 
     it 'should unregister extensions on specified registry' do


### PR DESCRIPTION
Convert a tabs block to an openblock. Only use HTML fragment blocks for the tab panel enclosure.