### PR TITLE
Link to `docs/use-with-antora.adoc` in `README.adoc`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -309,6 +309,10 @@ If you're not using other scoped extensions, you can pass in the extensions grou
 Asciidoctor.convert_file 'tabs.adoc', extensions: Asciidoctor::Tabs::Extensions.group, safe: :safe
 ----
 
+=== Antora
+
+See [this page](docs/use-with-antora.adoc) explaining how to use the tabs extension with Antora.
+
 == How it Works
 
 This extension works by transforming the dlist inside the example block into a tabbed interface.

--- a/README.adoc
+++ b/README.adoc
@@ -311,7 +311,7 @@ Asciidoctor.convert_file 'tabs.adoc', extensions: Asciidoctor::Tabs::Extensions.
 
 === Antora
 
-See [this page](docs/use-with-antora.adoc) explaining how to use the tabs extension with Antora.
+See xref:docs/use-with-antora.adoc[this page] explaining how to use the tabs extension with Antora.
 
 == How it Works
 

--- a/README.adoc
+++ b/README.adoc
@@ -15,8 +15,8 @@ An Asciidoctor extension that adds a tabs block to the AsciiDoc syntax.
 NOTE: This extension is intended to be used with HTML backends (e.g., `html5`).
 For all other backends (i.e., the filetype is not html), the custom block enclosure is discarded and its contents (a dlist) is converted normally.
 
-TIP: This extension is also published as an npm package named `@asciidoctor/tabs` for use with Asciidoctor.js.
-See the xref:js/README.adoc[README in the js folder] for details.
+TIP: This extension is also published as an npm package named `@asciidoctor/tabs` for use with Asciidoctor.js, and hence, with Antora.
+See xref:js/README.adoc[the npm package README] and xref:docs/use-with-antora.adoc[its Antora integration guide].
 
 == Overview
 
@@ -308,10 +308,6 @@ If you're not using other scoped extensions, you can pass in the extensions grou
 ----
 Asciidoctor.convert_file 'tabs.adoc', extensions: Asciidoctor::Tabs::Extensions.group, safe: :safe
 ----
-
-=== Antora
-
-See xref:docs/use-with-antora.adoc[this page] explaining how to use the tabs extension with Antora.
 
 == How it Works
 


### PR DESCRIPTION
`docs/use-with-antora.adoc` beautifully explains how to use the tabs extension with Antora. Yet it is not easy to discover – it did not even show up in my Google searches. Make it more discoverable by providing a link from the root `README.adoc`.